### PR TITLE
Fixed an error in OTDefaultAudioDevice

### DIFF
--- a/iOS-Sample/Hello-World/OTDefaultAudioDevice.m
+++ b/iOS-Sample/Hello-World/OTDefaultAudioDevice.m
@@ -997,8 +997,7 @@ static OSStatus playout_cb(void *ref_con,
                        numberOfSamples:tempNumFrames];
     } else
     {
-        uint32_t count =
-        [dev->_audioBus readRenderData:buffer_list->mBuffers[0].mData
+        count = [dev->_audioBus readRenderData:buffer_list->mBuffers[0].mData
                    numberOfSamples:num_frames];
     }
     


### PR DESCRIPTION
Variable count in OTDefaultAudioDevice was redeclared. Therefore, the value outside the else scope was always 0 after the else. This also caused a warning: "The variable count is never read".
