### PR TITLE
Docs update: unique session ID for the test.

### DIFF
--- a/Android-Sample/README.md
+++ b/Android-Sample/README.md
@@ -3,9 +3,8 @@ OpenTok Android Network Test Sample
 
 This sample shows how to use this OpenTok Android SDK to determine the appropriate audio and video
 settings to use in publishing a stream to an OpenTok session. To do this, the app publishes a test
-stream to the session and then uses the API to check the quality of that stream. Based on the
-quality, the app determines what the client can successfully publish to
-the session:
+stream to a test session and then uses the API to check the quality of that stream. Based on the
+quality, the app determines what the client can successfully publish to an OpenTok session:
 
 * The client can publish an audio-video stream at the specified resolution.
 
@@ -14,7 +13,8 @@ the session:
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-session.
+test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
+clients.
 
 ## Testing the app
 
@@ -45,16 +45,26 @@ To configure the app:
    private static final String APIKEY = "";
    ```
 
-   You can get your a test OpenTok session ID, a test token, and the API key at the
-   [OpenTok dashboard](https://dashboard.tokbox.com/).
+   **Important:** You must use a unique session, with its own session ID, for the network test. This
+   must be a different session than the one you will use to share audio-video streams between
+   clients. Do not publish more than one stream to the test session.
+
+   The app requires that each session uses the routed media mode -- one that uses
+   the [OpenTok Media Router](https://tokbox.com/developer/guides/create-session/#media-mode).
+   A routed session is required to get statistics for the stream published by the local client.
+
+   You can get your API key as well as a test session ID and token at the
+   [OpenTok dashboard](https://dashboard.tokbox.com/). However, in a shipping application, use
+   one of the [OpenTok server SDKs](https://tokbox.com/developer/sdks/server/) to generate a
+   session ID and token.
 
 6. Debug the project on a supported device.
 
    For a list of supported devices, see the "Developer and client requirements"
    on [this page](https://tokbox.com/developer/sdks/android/).
 
-The app uses a test stream to determine the client's ability to publish an stream.
-At the end of the test it reports one of the following:
+ The app uses a test stream and session to determine the client's ability to publish a stream
+ that has audio and video. At the end of the test it reports one of the following:
 
    * You're all set -- your client can publish an audio-video stream.
 
@@ -64,8 +74,8 @@ At the end of the test it reports one of the following:
 
 ## Understanding the code
 
-The MainActivity class connects to the OpenTok session. Upon connecting to the session,
-the app  connects initializes an OpenTok Publisher object it uses to test stream quality. 
+The MainActivity class connects to the test OpenTok session. Upon connecting to the session,
+the app connects initializes an OpenTok Publisher object it uses to test stream quality.
 Upon publishing, the app subscribes to the test stream it publishes:
 
 ```java

--- a/Android-Sample/README.md
+++ b/Android-Sample/README.md
@@ -13,8 +13,8 @@ quality, the app determines what the client can successfully publish to an OpenT
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
-clients.
+test session. Do not use the test session for your actual call. Use a separate OpenTok session
+(and session ID) to share audio-video streams between clients.
 
 ## Testing the app
 

--- a/iOS-Sample/README.md
+++ b/iOS-Sample/README.md
@@ -13,8 +13,8 @@ quality, the app determines what the client can successfully publish to an OpenT
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
-clients.
+test session. Do not use the test session for your actual call. Use a separate OpenTok session
+(and session ID) to share audio-video streams between clients.
 
 ## Testing the app
 

--- a/iOS-Sample/README.md
+++ b/iOS-Sample/README.md
@@ -3,9 +3,8 @@ OpenTok iOS Network Test Sample
 
 This sample shows how to use this OpenTok iOS SDK to determine the appropriate audio and video
 settings to use in publishing a stream to an OpenTok session. To do this, the app publishes a test
-stream to the session and then uses the API to check the quality of that stream. Based on the
-quality, the app determines what the client can successfully publish to
-the session:
+stream to a test session and then uses the API to check the quality of that stream. Based on the
+quality, the app determines what the client can successfully publish to an OpenTok session:
 
 * The client can publish an audio-video stream at the specified resolution.
 
@@ -14,7 +13,8 @@ the session:
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-session.
+test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
+clients.
 
 ## Testing the app
 
@@ -35,13 +35,23 @@ To configure the app:
    static NSString* const kToken = @"";
    ```
 
-   You can get your API key and API secret at the
-   [OpenTok dashboard](https://dashboard.tokbox.com/).
+   **Important:** You must use a unique session, with its own session ID, for the network test. This
+   must be a different session than the one you will use to share audio-video streams between
+   clients. Do not publish more than one stream to the test session.
+
+   The app requires that each session uses the routed media mode -- one that uses
+   the [OpenTok Media Router](https://tokbox.com/developer/guides/create-session/#media-mode).
+   A routed session is required to get statistics for the stream published by the local client.
+
+   You can get your API key as well as a test session ID and token at the
+   [OpenTok dashboard](https://dashboard.tokbox.com/). However, in a shipping application, use
+   one of the [OpenTok server SDKs](https://tokbox.com/developer/sdks/server/) to generate a
+   session ID and token.
 
 Now you can debug the app on a supported iOS device.
 
-The app uses a test stream to determine the client's ability to publish an stream that has audio
-and video. At the end of the test it reports one of the following:
+The app uses a test stream and session to determine the client's ability to publish a stream
+that has audio and video. At the end of the test it reports one of the following:
 
    * Your client can publish an audio-video stream.
 
@@ -77,7 +87,7 @@ self.resultLabel.text = @"";
                                    delegate:self];
 ```
 
-The OTNetworkTestDelegate class connects to the OpenTok session and publishes a test stream
+The OTNetworkTestDelegate class connects to the test OpenTok session and publishes a test stream
 to the session. Upon the stream being created, the app subscribes to it, so that it can
 collect statistics for it.
 

--- a/js-sample/README.md
+++ b/js-sample/README.md
@@ -3,9 +3,8 @@ OpenTok.js Network Test Sample
 
 This sample shows how to use OpenTok.js to determine the appropriate audio and video settings
 to use in publishing a stream to an OpenTok session. To do this, the app publishes a test
-stream to the session and then uses the API to check the quality of that stream. Based on the
-quality, the app determines what the client can successfully publish to
-the session:
+stream to a test session and then uses the API to check the quality of that stream. Based on the
+quality, the app determines what the client can successfully publish to an OpenTok session:
 
 * The client can publish an audio-video stream at the default resolution (640-by-480 pixels).
 
@@ -14,7 +13,8 @@ the session:
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-session.
+test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
+clients.
 
 ## Testing the app
 
@@ -29,7 +29,11 @@ To configure and test the app:
    var TOKEN = '';
    ```
 
-   Note that the app requires that the session that uses the routed media mode -- one that uses
+   **Important:** You must use a unique session, with its own session ID, for the network test. This
+   must be a different session than the one you will use to share audio-video streams between
+   clients. Do not publish more than one stream to the test session.
+
+   The app requires that each session uses the routed media mode -- one that uses
    the [OpenTok Media Router](https://tokbox.com/developer/guides/create-session/#media-mode).
    A routed session is required to get statistics for the stream published by the local client.
 
@@ -45,8 +49,8 @@ To configure and test the app:
 
 4. Grant the page access to your camera and microphone.
 
-5. The app uses a test stream to determine the client's ability to publish an stream that has a
-   640-by-480-pixel video. At the end of the test it reports one of the following:
+5. The app uses a test stream and session to determine the client's ability to publish a stream
+   that has a 640-by-480-pixel video. At the end of the test it reports one of the following:
 
    * You're all set -- your client can publish an audio-video stream that uses
      640-by-480-pixel video.
@@ -58,7 +62,8 @@ To configure and test the app:
 ## Understanding the code
 
 The main app.js file connects initializes an OpenTok publisher it uses to test stream quality.
-It also connects to the OpenTok session. Upon connecting to the session and initializing the publisher, the app subscribes to the test stream it publishes:
+It also connects to the OpenTok test session. Upon connecting to the session and publishing
+a stream, the app subscribes to the test stream it publishes:
 
 ```javascript
 subscriber = session.subscribe(

--- a/js-sample/README.md
+++ b/js-sample/README.md
@@ -13,8 +13,8 @@ quality, the app determines what the client can successfully publish to an OpenT
 * The client is unable to publish.
 
 The sample app only subscribes to the test stream. It does not subscribe to other streams in the
-test session. Use a separate OpenTok session (and session ID) to share audio-video streams between
-clients.
+test session. Do not use the test session for your actual call. Use a separate OpenTok session
+(and session ID) to share audio-video streams between clients.
 
 ## Testing the app
 


### PR DESCRIPTION
You must use different OpenTok sessions for the test and for the target app.
