### PR TITLE
Fix bug with bandwidth calculation

### DIFF
--- a/js-sample/app.js
+++ b/js-sample/app.js
@@ -306,7 +306,7 @@ function bandwidthCalculatorObj(config) {
           if (sampleWindowSize !== 0) {
             reportFunction(calculatePerSecondStats(
               statsBuffer,
-              sampleWindowSize
+              sampleWindowSize + (config.pollingInterval / 1000)
             ));
           }
         });


### PR DESCRIPTION
The Kbps is calculated by the total bytes divided by the size of the sample window (from max timestamp minus min timestamp).

This does not take into account the pollingInterval elapsed before generating the first timestamp, resulting in slightly higher bandwidth calculated than actually seen in the sample window size.