### PR TITLE
Update README benchmarks 3% packetloss Acceptable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ For the given qualities and resolutions, all the following conditions must met.
 | Excellent  | 640x480 @ 30           | > 600       | < 0.5%      |
 | Excellent  | 352x288 @ 30           | > 300       | < 0.5%      |
 | Excellent  | 320x240 @ 30           | > 300       | < 0.5%      |
-| Acceptable | 1280x720 @ 30          | > 350       | < 0.3%      |
-| Acceptable | 640x480 @ 30           | > 250       | < 0.3%      |
-| Acceptable | 352x288 @ 30           | > 150       | < 0.3%      |
-| Acceptable | 320x240 @ 30           | > 150       | < 0.3%      |
+| Acceptable | 1280x720 @ 30          | > 350       | < 3%        |
+| Acceptable | 640x480 @ 30           | > 250       | < 3%        |
+| Acceptable | 352x288 @ 30           | > 150       | < 3%        |
+| Acceptable | 320x240 @ 30           | > 150       | < 3%        |
 
 Note that the default publish settings for video are 640x480 pixels @ 30 fps in OpenTok.js and the
 OpenTok iOS SDK. The default is 352x288 @ 30 fps in the OpenTok Android SDK.


### PR DESCRIPTION
* It appears like this is a typo in the README. It wouldn't make sense
for packetloss percentage for 'Excellent' to be higher than 'Acceptable'
* It looks like the 'Acceptable' threshold for packetloss should be 3% and
the 'Excellent' threshold should be 0.5%
* The code also checks for 3% for video (packetLossRatioPerSecond: 0.03):
* https://github.com/opentok/opentok-network-test/blob/a9ea9331d99aea890af74877aad80a0e952cc6b7/js-sample/app.js#L26