### PR TITLE
Fix bug when missing a camera

### DIFF
--- a/js-sample/app.js
+++ b/js-sample/app.js
@@ -28,15 +28,15 @@ var testStreamingCapability = function(subscriber, callback) {
 
       if (audioSupported) {
         return callback(false, {
-          text: 'You can\'t do video because no camera was found, '
-            + 'but your bandwidth can support an audio only stream',
+          text: 'You can\'t do video because no camera was found, ' +
+            'but your bandwidth can support an audio-only stream',
           icon: 'assets/icon_warning.svg'
         });
       }
 
       return callback(false, {
-          text: 'You can\'t do video because no camera was found, '
-            + 'and your bandwidth is too low for an audio only stream',
+          text: 'You can\'t do video because no camera was found, ' +
+            'and your bandwidth is too low for an audio-only stream',
         icon: 'assets/icon_warning.svg'
       });
     }
@@ -226,7 +226,7 @@ function min(arr) {
 function calculatePerSecondStats(statsBuffer, seconds) {
   var stats = {};
   var activeMediaTypes = Object.keys(statsBuffer[0] || {})
-    .filter(function (key) {
+    .filter(function(key) {
       return key !== 'timestamp';
     });
 
@@ -303,12 +303,12 @@ function bandwidthCalculatorObj(config) {
         video: {}
       };
       var activeMediaTypes = subscriber.stream.channel
-        .map(function (channel) {
+        .map(function(channel) {
           if (channel.active === true) {
             return channel.type;
           }
         })
-        .filter(function (mediaType) {
+        .filter(function(mediaType) {
           return !!mediaType;
         });
 

--- a/js-sample/app.js
+++ b/js-sample/app.js
@@ -21,6 +21,25 @@ var statusIconEl;
 var testStreamingCapability = function(subscriber, callback) {
   performQualityTest({subscriber: subscriber, timeout: TEST_TIMEOUT_MS}, function(error, results) {
     console.log('Test concluded', results);
+    // If we tried to set video constraints, but no video data was found
+    if (!results.video) {
+      var audioSupported = results.audio.bitsPerSecond > 25000 &&
+          results.audio.packetLossRatioPerSecond < 0.05;
+
+      if (audioSupported) {
+        return callback(false, {
+          text: 'You can\'t do video because no camera was found, '
+            + 'but your bandwidth can support an audio only stream',
+          icon: 'assets/icon_warning.svg'
+        });
+      }
+
+      return callback(false, {
+          text: 'You can\'t do video because no camera was found, '
+            + 'and your bandwidth is too low for an audio only stream',
+        icon: 'assets/icon_warning.svg'
+      });
+    }
 
     var audioVideoSupported = results.video.bitsPerSecond > 250000 &&
       results.video.packetLossRatioPerSecond < 0.03 &&
@@ -206,7 +225,12 @@ function min(arr) {
 
 function calculatePerSecondStats(statsBuffer, seconds) {
   var stats = {};
-  ['video', 'audio'].forEach(function(type) {
+  var activeMediaTypes = Object.keys(statsBuffer[0] || {})
+    .filter(function (key) {
+      return key !== 'timestamp';
+    });
+
+  activeMediaTypes.forEach(function(type) {
     stats[type] = {
       packetsPerSecond: sum(pluck(statsBuffer, type), 'packetsReceived') / seconds,
       bitsPerSecond: (sum(pluck(statsBuffer, type), 'bytesReceived') * 8) / seconds,
@@ -278,6 +302,16 @@ function bandwidthCalculatorObj(config) {
         audio: {},
         video: {}
       };
+      var activeMediaTypes = subscriber.stream.channel
+        .map(function (channel) {
+          if (channel.active === true) {
+            return channel.type;
+          }
+        })
+        .filter(function (mediaType) {
+          return !!mediaType;
+        });
+
 
       intervalId = window.setInterval(function() {
         config.subscriber.getStats(function(error, stats) {
@@ -285,7 +319,7 @@ function bandwidthCalculatorObj(config) {
           var nowMs = new Date().getTime();
           var sampleWindowSize;
 
-          ['audio', 'video'].forEach(function(type) {
+          activeMediaTypes.forEach(function(type) {
             snapshot[type] = Object.keys(stats[type]).reduce(function(result, key) {
               result[key] = stats[type][key] - (last[type][key] || 0);
               last[type][key] = stats[type][key];


### PR DESCRIPTION
Previously, the test would test for both audio and video no matter the situation (which is fine), but when the test rig was missing a video capture device (no webcam, laptop lid closed) it would try to calculate stats for video anyway, even though the relevant video stats did not exist, which made the script prematurely end. (this is not fine)

This PR gets the script to check for what media types are actually active in the subscriber before checking the stats for it, and adds an output case to the UI where it will inform the user of the missing video capture device, but also still check the audio stats in that scenario.